### PR TITLE
fix: delete tags with go backend

### DIFF
--- a/backend/internal/api/handlers/tags.go
+++ b/backend/internal/api/handlers/tags.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ofkm/svelocker-ui/backend/internal/repository"
@@ -46,4 +48,30 @@ func (h *TagHandler) GetTag(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, tag)
+}
+
+// DeleteTag handles requests to delete a specific tag
+func (h *TagHandler) DeleteTag(c *gin.Context) {
+	repoName := c.Param("name")
+	imageName := c.Param("image")
+	tagName := c.Param("tag")
+
+	// Call repository method to delete the tag
+	err := h.repo.DeleteTag(c, repoName, imageName, tagName)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "record not found") {
+			status = http.StatusNotFound
+		}
+
+		c.JSON(status, gin.H{
+			"error": fmt.Sprintf("Failed to delete tag: %v", err),
+		})
+		return
+	}
+
+	// Return success response
+	c.JSON(http.StatusOK, gin.H{
+		"message": fmt.Sprintf("Tag %s deleted successfully", tagName),
+	})
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -53,6 +53,7 @@ func SetupRoutes(
 			// Tag routes
 			repos.GET("/:name/images/:image/tags", tagHandler.ListTags)
 			repos.GET("/:name/images/:image/tags/:tag", tagHandler.GetTag)
+			repos.DELETE("/:name/images/:image/tags/:tag", tagHandler.DeleteTag)
 		}
 	}
 }

--- a/backend/internal/repository/gorm/tag_repository.go
+++ b/backend/internal/repository/gorm/tag_repository.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ofkm/svelocker-ui/backend/internal/models"

--- a/backend/internal/repository/gorm/tag_repository.go
+++ b/backend/internal/repository/gorm/tag_repository.go
@@ -171,7 +171,9 @@ func (r *tagRepository) DeleteTag(ctx context.Context, repoName, imageName, tagN
 		return err
 	}
 
-	log.Printf("Successfully deleted tag %s from database", tagName)
+	sanitizedTagName := strings.ReplaceAll(tagName, "\n", "")
+	sanitizedTagName = strings.ReplaceAll(sanitizedTagName, "\r", "")
+	log.Printf("Successfully deleted tag %s from database", sanitizedTagName)
 
 	// Registry path setup
 	baseURL := os.Getenv("PUBLIC_REGISTRY_URL")

--- a/backend/internal/services/registry_client.go
+++ b/backend/internal/services/registry_client.go
@@ -303,7 +303,9 @@ func (c *RegistryClient) DeleteManifest(ctx context.Context, repository, digest 
 	maxRetries := 3
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		log.Printf("DELETE request attempt %d to %s", attempt, url)
+		sanitizedURL := strings.ReplaceAll(url, "\n", "")
+		sanitizedURL = strings.ReplaceAll(sanitizedURL, "\r", "")
+		log.Printf("DELETE request attempt %d to %s", attempt, sanitizedURL)
 		resp, err = c.client.Do(req)
 
 		if err == nil {
@@ -312,7 +314,9 @@ func (c *RegistryClient) DeleteManifest(ctx context.Context, repository, digest 
 
 			if statusOK {
 				defer resp.Body.Close()
-				log.Printf("Successfully deleted manifest %s from %s", digest, repository)
+				sanitizedRepository := strings.ReplaceAll(repository, "\n", "")
+				sanitizedRepository = strings.ReplaceAll(sanitizedRepository, "\r", "")
+				log.Printf("Successfully deleted manifest %s from %s", digest, sanitizedRepository)
 				return nil
 			}
 		}
@@ -324,7 +328,9 @@ func (c *RegistryClient) DeleteManifest(ctx context.Context, repository, digest 
 
 			// If NotFound, consider this a success (already deleted)
 			if resp.StatusCode == http.StatusNotFound {
-				log.Printf("Manifest %s not found in %s (already deleted)", digest, repository)
+				sanitizedRepository := strings.ReplaceAll(repository, "\n", "")
+				sanitizedRepository = strings.ReplaceAll(sanitizedRepository, "\r", "")
+				log.Printf("Manifest %s not found in %s (already deleted)", digest, sanitizedRepository)
 				return nil
 			}
 

--- a/backend/internal/services/registry_client.go
+++ b/backend/internal/services/registry_client.go
@@ -273,7 +273,8 @@ func (c *RegistryClient) DeleteManifest(ctx context.Context, repository, digest 
 	repository = strings.Trim(repository, "/")
 
 	// Construct the URL for deleting the manifest
-	url := fmt.Sprintf("%s/v2/%s/manifests/%s", c.baseURL, repository, digest)
+	url := fmt.Sprintf("%s/v2/%s/blobs/%s", c.baseURL, repository, digest)
+	// `${registryUrl}/v2/${repo}/manifests/${digest
 
 	// Create a new DELETE request
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)

--- a/backend/internal/utils/oci_utils.go
+++ b/backend/internal/utils/oci_utils.go
@@ -48,7 +48,7 @@ func FilterAttestationManifests(manifestJson string) (string, error) {
 	}
 
 	// Filter out attestation manifests if present
-	if manifest.Manifests != nil && len(manifest.Manifests) > 0 {
+	if len(manifest.Manifests) > 0 {
 		var filteredManifests []*OCIManifest
 
 		for _, m := range manifest.Manifests {

--- a/backend/internal/utils/oci_utils.go
+++ b/backend/internal/utils/oci_utils.go
@@ -1,0 +1,183 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+)
+
+// OCI manifest structure
+type OCIManifest struct {
+	MediaType     string            `json:"mediaType,omitempty"`
+	SchemaVersion int               `json:"schemaVersion,omitempty"`
+	Config        *OCIDescriptor    `json:"config,omitempty"`
+	Layers        []*OCIDescriptor  `json:"layers,omitempty"`
+	Manifests     []*OCIManifest    `json:"manifests,omitempty"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+	Platform      *OCIPlatform      `json:"platform,omitempty"`
+	Digest        string            `json:"digest,omitempty"`
+}
+
+type OCIDescriptor struct {
+	MediaType   string            `json:"mediaType,omitempty"`
+	Digest      string            `json:"digest,omitempty"`
+	Size        int64             `json:"size,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Platform    *OCIPlatform      `json:"platform,omitempty"`
+}
+
+type OCIPlatform struct {
+	Architecture string `json:"architecture,omitempty"`
+	OS           string `json:"os,omitempty"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+// FilterAttestationManifests removes attestation manifests and ensures deterministic ordering
+// Similar to TypeScript filterAttestationManifests function
+func FilterAttestationManifests(manifestJson string) (string, error) {
+	var manifest OCIManifest
+
+	// Parse the manifest JSON
+	if err := json.Unmarshal([]byte(manifestJson), &manifest); err != nil {
+		log.Printf("Error parsing manifest JSON: %v", err)
+		return manifestJson, err
+	}
+
+	// Filter out attestation manifests if present
+	if manifest.Manifests != nil && len(manifest.Manifests) > 0 {
+		var filteredManifests []*OCIManifest
+
+		for _, m := range manifest.Manifests {
+			if m.Annotations == nil || m.Annotations["vnd.docker.reference.type"] == "" {
+				filteredManifests = append(filteredManifests, m)
+			}
+		}
+
+		// Sort manifests by digest for deterministic ordering
+		sort.Slice(filteredManifests, func(i, j int) bool {
+			// Check if there's a digest field in the manifest annotations
+			digestI := ""
+			digestJ := ""
+
+			if filteredManifests[i].Annotations != nil && filteredManifests[i].Annotations["org.opencontainers.image.ref.name"] != "" {
+				digestI = filteredManifests[i].Annotations["org.opencontainers.image.ref.name"]
+			}
+
+			if filteredManifests[j].Annotations != nil && filteredManifests[j].Annotations["org.opencontainers.image.ref.name"] != "" {
+				digestJ = filteredManifests[j].Annotations["org.opencontainers.image.ref.name"]
+			}
+
+			return digestI < digestJ
+		})
+
+		manifest.Manifests = filteredManifests
+	}
+
+	// Ensure deterministic JSON stringification
+	formattedJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		log.Printf("Error marshaling filtered manifest: %v", err)
+		return manifestJson, err
+	}
+
+	return string(formattedJSON), nil
+}
+
+// CalculateSHA256 calculates the SHA256 hash of a string after normalizing
+// Similar to TypeScript calculateSha256 function
+func CalculateSHA256(content string) string {
+	// Remove all whitespace and newlines for consistent hashing
+	normalized := strings.ReplaceAll(content, " ", "")
+	normalized = strings.ReplaceAll(normalized, "\n", "")
+	normalized = strings.ReplaceAll(normalized, "\r", "")
+	normalized = strings.ReplaceAll(normalized, "\t", "")
+
+	hash := sha256.Sum256([]byte(normalized))
+	return fmt.Sprintf("sha256:%x", hash)
+}
+
+// GenerateManifestDigest creates a SHA256 digest from a manifest object
+// Similar to TypeScript generateManifestDigest function
+func GenerateManifestDigest(manifest interface{}) (string, error) {
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		log.Printf("Error generating manifest JSON: %v", err)
+		return fmt.Sprintf("sha256:error-generating-digest-%d", time.Now().Unix()), err
+	}
+
+	hash := sha256.Sum256(manifestJSON)
+	return fmt.Sprintf("sha256:%x", hash), nil
+}
+
+// NormalizeAndCalculateManifestDigest takes raw manifest JSON and calculates the correct digest
+// This combines both filtering and hash calculation
+func NormalizeAndCalculateManifestDigest(manifestJSON string) string {
+	// First filter out attestation manifests and ensure deterministic format
+	filteredJSON, err := FilterAttestationManifests(manifestJSON)
+	if err != nil {
+		log.Printf("Warning: Error filtering attestations, using original manifest: %v", err)
+		filteredJSON = manifestJSON
+	}
+
+	// Then calculate the SHA256 of the normalized content
+	return CalculateSHA256(filteredJSON)
+}
+
+// GetCorrectDeleteDigest extracts the proper digest for deletion from headers and manifest
+func GetCorrectDeleteDigest(contentDigestHeader string, manifestJSON string) string {
+	// First try to use the Docker-Content-Digest header if available
+	if contentDigestHeader != "" {
+		// Remove any quotes from the header value
+		contentDigestHeader = strings.ReplaceAll(contentDigestHeader, "\"", "")
+		return contentDigestHeader
+	}
+
+	// If no header is available, calculate the digest from the manifest JSON
+	return NormalizeAndCalculateManifestDigest(manifestJSON)
+}
+
+// GetPlatformSpecificManifest extracts the appropriate manifest for a given platform from an OCI index
+func GetPlatformSpecificManifest(manifestJSON string, architecture string, os string) (string, error) {
+	var manifest OCIManifest
+
+	// Parse the manifest JSON
+	if err := json.Unmarshal([]byte(manifestJSON), &manifest); err != nil {
+		log.Printf("Error parsing manifest JSON: %v", err)
+		return "", err
+	}
+
+	// Check if this is an OCI index or Docker manifest list
+	if manifest.MediaType == "application/vnd.oci.image.index.v1+json" ||
+		manifest.MediaType == "application/vnd.docker.distribution.manifest.list.v2+json" {
+
+		// Look for the specified platform first
+		for _, m := range manifest.Manifests {
+			if m.Platform != nil &&
+				m.Platform.Architecture == architecture &&
+				m.Platform.OS == os {
+				return m.Digest, nil
+			}
+		}
+
+		// If no exact match, try to find a manifest without platform-specific attestations
+		for _, m := range manifest.Manifests {
+			if m.Annotations == nil || m.Annotations["vnd.docker.reference.type"] == "" {
+				return m.Digest, nil
+			}
+		}
+
+		// As a last resort, return the first manifest's digest
+		if len(manifest.Manifests) > 0 {
+			return manifest.Manifests[0].Digest, nil
+		}
+
+		return "", fmt.Errorf("no valid manifests found in index")
+	}
+
+	// If it's not an index, return an error
+	return "", fmt.Errorf("not an OCI image index or Docker manifest list")
+}

--- a/frontend/src/lib/services/tag-service.ts
+++ b/frontend/src/lib/services/tag-service.ts
@@ -43,4 +43,17 @@ export class TagService {
 			throw error;
 		}
 	}
+
+	/**
+	 * Delete a tag from a repository
+	 */
+	async deleteTag(repoName: string, imageName: string, tagName: string): Promise<void> {
+		try {
+			await axios.delete(`${this.baseUrl}/api/v1/repositories/${encodeURIComponent(repoName)}/images/${encodeURIComponent(imageName)}/tags/${encodeURIComponent(tagName)}`);
+			this.logger.info(`Successfully deleted tag ${tagName} from image ${imageName} in repository ${repoName}`);
+		} catch (error) {
+			this.logger.error(`Failed to delete tag ${tagName}:`, error);
+			throw error;
+		}
+	}
 }

--- a/frontend/src/routes/details/[repo]/[image]/[tag]/+page.server.ts
+++ b/frontend/src/routes/details/[repo]/[image]/[tag]/+page.server.ts
@@ -16,27 +16,21 @@ export const load: PageServerLoad = async ({ params }) => {
 
 export const actions: Actions = {
 	deleteTag: async ({ params, request }) => {
-		try {
-			const tagService = TagService.getInstance();
+		const tagService = TagService.getInstance();
 
-			// Extract form data (for any potential confirmation fields)
-			const formData = await request.formData();
-			const confirmation = formData.get('confirm');
+		// Extract form data
+		const formData = await request.formData();
+		const confirmation = formData.get('confirm');
 
-			// Optional: Check for confirmation
-			if (confirmation !== 'true') {
-				return { success: false, error: 'Please confirm deletion' };
-			}
-
-			// Call delete method in service
-			await tagService.deleteTag(params.repo, params.image, params.tag);
-
-			// Redirect to the image page after successful deletion
-			throw redirect(303, `/details/${params.repo}/${params.image}`);
-		} catch (err) {
-			// Handle errors
-			console.error('Failed to delete tag:', err);
-			throw error(500, { message: 'Failed to delete tag' });
+		// Optional: Check for confirmation
+		if (confirmation !== 'true') {
+			return { success: false, error: 'Please confirm deletion' };
 		}
+
+		// Call delete method in service
+		await tagService.deleteTag(params.repo, params.image, params.tag);
+
+		// Throw a redirect instead of returning an object
+		throw redirect(303, `/details/${params.repo}/${params.image}`);
 	}
 };

--- a/frontend/src/routes/details/[repo]/[image]/[tag]/+page.server.ts
+++ b/frontend/src/routes/details/[repo]/[image]/[tag]/+page.server.ts
@@ -1,5 +1,6 @@
-import type { PageServerLoad } from './$types';
+import type { PageServerLoad, Actions } from './$types';
 import { TagService } from '$lib/services/tag-service';
+import { error, redirect } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params }) => {
 	const tagService = TagService.getInstance();
@@ -11,4 +12,31 @@ export const load: PageServerLoad = async ({ params }) => {
 		imageName: params.image,
 		tagName: params.tag
 	};
+};
+
+export const actions: Actions = {
+	deleteTag: async ({ params, request }) => {
+		try {
+			const tagService = TagService.getInstance();
+
+			// Extract form data (for any potential confirmation fields)
+			const formData = await request.formData();
+			const confirmation = formData.get('confirm');
+
+			// Optional: Check for confirmation
+			if (confirmation !== 'true') {
+				return { success: false, error: 'Please confirm deletion' };
+			}
+
+			// Call delete method in service
+			await tagService.deleteTag(params.repo, params.image, params.tag);
+
+			// Redirect to the image page after successful deletion
+			throw redirect(303, `/details/${params.repo}/${params.image}`);
+		} catch (err) {
+			// Handle errors
+			console.error('Failed to delete tag:', err);
+			throw error(500, { message: 'Failed to delete tag' });
+		}
+	}
 };

--- a/frontend/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/frontend/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -17,6 +17,7 @@
 	import ScrollArea from '$lib/components/ui/scroll-area/scroll-area.svelte';
 	import type { Tag, TagMetadata, ImageLayer } from '$lib/types/tag-type';
 	import { formatSize, getTotalLayerSize } from '$lib/utils/formatting';
+	import { enhance } from '$app/forms';
 
 	interface Props {
 		data: PageData;
@@ -41,8 +42,9 @@
 	// Check if this is the latest tag
 	let isLatest = $derived(tagName === 'latest');
 
-	onMount(async () => {
+	let showDeleteModal = $state(false);
 
+	onMount(async () => {
 		if (!metadata || Object.keys(metadata).length === 0) {
 			try {
 				console.warn('Tag metadata appears to be empty');
@@ -224,41 +226,9 @@
 							Copy Docker Run
 						</Button>
 
-						<AlertDialog.Root>
-							<AlertDialog.Trigger class="{buttonVariants({ variant: 'destructive', size: 'sm' })} gap-2">
-								<Trash2 class="h-4 w-4" /> Delete Tag
-							</AlertDialog.Trigger>
-							<AlertDialog.Content>
-								<AlertDialog.Header>
-									<AlertDialog.Title class="font-light text-md">Are you sure you want to delete the following tag?<br /><span class="font-bold underline">{imageFullName}:{tagName}</span></AlertDialog.Title>
-									<AlertDialog.Description>This action <span class="font-extrabold">CAN NOT</span> be undone. <br /><span class="font-bold">All tags with the same config digest will be deleted.</span></AlertDialog.Description>
-								</AlertDialog.Header>
-								<AlertDialog.Footer>
-									<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-									<AlertDialog.Action
-										onclick={() => {
-											const digest = tag?.digest;
-											console.log('Selected digest:', digest);
-
-											if (!digest) {
-												toast.error('Error Deleting Docker Tag', {
-													description: 'No digest found for this tag'
-												});
-												return;
-											}
-
-											// Strip 'library/' prefix if present
-											const name = imageFullName.startsWith('library/') ? imageFullName.replace('library/', '') : imageFullName;
-
-											deleteTagBackend(name, digest);
-										}}
-										class={buttonVariants({ variant: 'destructive' })}
-									>
-										Delete
-									</AlertDialog.Action>
-								</AlertDialog.Footer>
-							</AlertDialog.Content>
-						</AlertDialog.Root>
+						<Button variant="destructive" size="sm" class="gap-2" onclick={() => (showDeleteModal = true)}>
+							<Trash2 class="h-4 w-4" /> Delete Tag
+						</Button>
 					</div>
 				</div>
 			</div>
@@ -329,6 +299,30 @@
 					<p class="text-muted-foreground">No layer information available for this image.</p>
 				</div>
 			{/if}
+
+			<!-- Delete Confirmation Modal -->
+			<AlertDialog.Root open={showDeleteModal} onOpenChange={(open) => (showDeleteModal = open)}>
+				<AlertDialog.Content>
+					<AlertDialog.Header>
+						<AlertDialog.Title class="font-light text-md">
+							Are you sure you want to delete the following tag?<br />
+							<span class="font-bold underline">{imageFullName}:{tagName}</span>
+						</AlertDialog.Title>
+						<AlertDialog.Description>
+							This action <span class="font-extrabold">CAN NOT</span> be undone.
+							<br />
+							<span class="font-bold">All tags with the same config digest will be deleted.</span>
+						</AlertDialog.Description>
+					</AlertDialog.Header>
+					<AlertDialog.Footer>
+						<AlertDialog.Cancel onclick={() => (showDeleteModal = false)}>Cancel</AlertDialog.Cancel>
+						<form action="?/deleteTag" method="POST" use:enhance>
+							<input type="hidden" name="confirm" value="true" />
+							<button type="submit" class={buttonVariants({ variant: 'destructive' })}> Delete </button>
+						</form>
+					</AlertDialog.Footer>
+				</AlertDialog.Content>
+			</AlertDialog.Root>
 		</div>
 	</div>
 {/if}

--- a/frontend/src/routes/details/[repo]/[image]/[tag]/+page.svelte
+++ b/frontend/src/routes/details/[repo]/[image]/[tag]/+page.svelte
@@ -18,6 +18,7 @@
 	import type { Tag, TagMetadata, ImageLayer } from '$lib/types/tag-type';
 	import { formatSize, getTotalLayerSize } from '$lib/utils/formatting';
 	import { enhance } from '$app/forms';
+	import { goto } from '$app/navigation';
 
 	interface Props {
 		data: PageData;
@@ -124,6 +125,14 @@
 		}
 
 		return value || 'None';
+	}
+
+	function handleEnhance() {
+		return async ({ result }) => {
+			if (result.type === 'redirect') {
+				goto(result.location);
+			}
+		};
 	}
 </script>
 
@@ -316,9 +325,9 @@
 					</AlertDialog.Header>
 					<AlertDialog.Footer>
 						<AlertDialog.Cancel onclick={() => (showDeleteModal = false)}>Cancel</AlertDialog.Cancel>
-						<form action="?/deleteTag" method="POST" use:enhance>
+						<form action="?/deleteTag" method="POST" use:enhance={handleEnhance}>
 							<input type="hidden" name="confirm" value="true" />
-							<button type="submit" class={buttonVariants({ variant: 'destructive' })}> Delete </button>
+							<button type="submit" class={buttonVariants({ variant: 'destructive' })}>Delete</button>
 						</form>
 					</AlertDialog.Footer>
 				</AlertDialog.Content>


### PR DESCRIPTION
Currently Giving a 500 error

Fixes: https://github.com/ofkm/svelocker-ui/issues/215

## Summary by Sourcery

Implement tag deletion functionality across the backend and frontend, allowing users to delete Docker image tags from both the database and container registry

New Features:
- Add ability to delete Docker image tags with full support in backend and frontend

Bug Fixes:
- Ensure consistent tag deletion across database and container registry

Enhancements:
- Implement a robust tag deletion process with database transaction support
- Add registry manifest deletion capability

## Summary by Sourcery

Implement comprehensive tag deletion functionality across backend and frontend, enabling users to delete Docker image tags from both the database and container registry

New Features:
- Add full-featured tag deletion capability with support for deleting tags from both database and container registry

Bug Fixes:
- Resolve 500 error when attempting to delete tags
- Ensure consistent tag deletion across different registry and database systems

Enhancements:
- Implement robust tag deletion process with database transaction support
- Add advanced manifest deletion capability with retry and error handling